### PR TITLE
Moved the audit replay status class to the api so that it can be used…

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,40 @@
 The audit service is a DATAWAVE microservice that provides
 query audit capabilities.
 
-### Root Context
+### Audit Context
 
 *https://host:port/audit/v1/*
 
 ### User API
 
-| Method | Operation | Description | Request Body |
-|:-------|:----------|:------------|:-------------|
-| `POST` | /audit    | Sends an audit request | [AuditRequest] |
+| Method | Operation | Description            | Path Param | Request Body   |
+|:-------|:----------|:-----------------------|:-----------|:---------------|
+| `POST` | /audit    | Sends an audit request | N/A        | [AuditRequest] |
+
+---
+
+### Replay Context
+
+*https://host:port/audit/v1/replay/*
+
+### Replay API
+
+| Method   | Operation       | Description                                    | Path Param | Request Body    |
+|:---------|:----------------|:-----------------------------------------------|:-----------|:----------------|
+| `POST`   | /create         | Creates an audit replay request                | N/A        | [ReplayRequest] |
+| `POST`   | /createAndStart | Creates an audit replay request, and starts it | N/A        | [ReplayRequest] |
+| `PUT`    | /{id}/start     | Starts an audit replay                         | [ReplayId] | N/A             |
+| `GET`    | /{id}/status    | Gets the status of an audit replay             | [ReplayId] | N/A             |
+| `PUT`    | /{id}/update    | Updates an audit replay                        | [ReplayId] | [SendRate]      |
+| `PUT`    | /{id}/stop      | Stops an audit replay                          | [ReplayId] | N/A             |
+| `PUT`    | /{id}/resume    | Resumes an audit replay                        | [ReplayId] | N/A             |
+| `DELETE` | /{id}/delete    | Deletes an audit replay                        | [ReplayId] | N/A             |
+| `PUT`    | /startAll       | Starts all audit replays                       | N/A        | N/A             |
+| `GET`    | /statusAll      | Gets the status for all audit replays          | N/A        | N/A             |
+| `PUT`    | /updateAll      | Updates all audit replays                      | N/A        | [SendRate]      |
+| `PUT`    | /stopAll        | Stops all audit replays                        | N/A        | N/A             |
+| `PUT`    | /resumeAll      | Resumes all audit replays                      | N/A        | N/A             |
+| `DELETE` | /deleteAll      | Deletes all audit replays                      | N/A        | N/A             |
 
 ---
 

--- a/api/src/main/java/datawave/microservice/audit/replay/status/Status.java
+++ b/api/src/main/java/datawave/microservice/audit/replay/status/Status.java
@@ -12,7 +12,7 @@ import java.util.stream.Collectors;
 public class Status implements Serializable {
     
     public enum ReplayState {
-        CREATED, RUNNING, IDLE, STOPPED, FINISHED, FAILED
+        CREATED, RUNNING, STOPPED, FINISHED, FAILED
     }
     
     public enum FileState {

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -18,7 +18,7 @@
     </scm>
     <properties>
         <version.hadoop>2.6.0</version.hadoop>
-        <version.microservice.audit-api>1.4</version.microservice.audit-api>
+        <version.microservice.audit-api>1.8-SNAPSHOT</version.microservice.audit-api>
         <version.microservice.hazelcast-client>1.5</version.microservice.hazelcast-client>
         <version.microservice.starter>1.6.3</version.microservice.starter>
     </properties>

--- a/service/src/main/java/datawave/microservice/audit/auditors/file/FileAuditor.java
+++ b/service/src/main/java/datawave/microservice/audit/auditors/file/FileAuditor.java
@@ -62,9 +62,6 @@ public class FileAuditor implements Auditor {
         
         fileSystem = FileSystem.get(path.toUri(), config);
         
-        if (!fileSystem.exists(path))
-            fileSystem.mkdirs(path);
-        
         String sdfString = "yyyyMMdd_HHmmss.SSS'.json'";
         if (builder.prefix != null && !builder.prefix.isEmpty())
             sdfString = "'" + builder.prefix + "-'" + sdfString;
@@ -74,6 +71,10 @@ public class FileAuditor implements Auditor {
     
     @Override
     public void audit(AuditParameters auditParameters) throws Exception {
+        
+        // create the audit path if it doesn't exist
+        if (!fileSystem.exists(path))
+            fileSystem.mkdirs(path);
         
         // convert the messages to JSON
         String jsonAuditParams = mapper.writeValueAsString(auditParameters.toMap()) + "\n";

--- a/service/src/main/java/datawave/microservice/audit/replay/ReplayController.java
+++ b/service/src/main/java/datawave/microservice/audit/replay/ReplayController.java
@@ -550,7 +550,7 @@ public class ReplayController {
     }
     
     private boolean stop(Status status, boolean publishEvent) {
-        // is the replay running/idle?
+        // is the replay running?
         if (status.getState() == RUNNING) {
             
             // if we own it, stop it. otherwise, fire an event to all of the audit services

--- a/service/src/main/java/datawave/microservice/audit/replay/runner/ReplayTask.java
+++ b/service/src/main/java/datawave/microservice/audit/replay/runner/ReplayTask.java
@@ -8,9 +8,7 @@ import datawave.microservice.audit.replay.status.StatusCache;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.RemoteIterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,8 +26,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static datawave.microservice.audit.replay.status.Status.ReplayState;
 import static datawave.microservice.audit.replay.status.Status.FileState;
+import static datawave.microservice.audit.replay.status.Status.ReplayState;
 import static datawave.webservice.common.audit.AuditParameters.AUDIT_ID;
 import static java.nio.charset.StandardCharsets.UTF_8;
 

--- a/service/src/test/java/datawave/microservice/audit/replay/AuditReplayTest.java
+++ b/service/src/test/java/datawave/microservice/audit/replay/AuditReplayTest.java
@@ -1386,17 +1386,17 @@ public class AuditReplayTest {
                 fileStatus);
         // @formatter:on
         
-        // Check the status until it is idle
+        // Check the status until it is stopped
         status = toStatus(jwtRestTemplate.exchange(authUser, HttpMethod.GET, statusUri, String.class));
         numRetries = 20;
-        while (status.getState() != Status.ReplayState.IDLE && numRetries-- != 0) {
+        while (status.getState() != Status.ReplayState.STOPPED && numRetries-- != 0) {
             Thread.sleep(250);
             status = toStatus(jwtRestTemplate.exchange(authUser, HttpMethod.GET, statusUri, String.class));
         }
         
         // @formatter:off
         assertStatus(
-                Status.ReplayState.IDLE,
+                Status.ReplayState.STOPPED,
                 tempDir.toURI().toString(),
                 0L,
                 2,
@@ -1411,7 +1411,7 @@ public class AuditReplayTest {
         map = new LinkedMultiValueMap<>();
         map.add("sendRate", "200");
         
-        // Create and start the audit replay request
+        // Update replay request
         requestEntity = jwtRestTemplate.createRequestEntity(authUser, map, null, HttpMethod.PUT, updateUri);
         ResponseEntity<String> updateResp = jwtRestTemplate.exchange(requestEntity, String.class);
         
@@ -1422,7 +1422,7 @@ public class AuditReplayTest {
         
         // @formatter:off
         assertStatus(
-                Status.ReplayState.IDLE,
+                Status.ReplayState.STOPPED,
                 tempDir.toURI().toString(),
                 200L,
                 2,


### PR DESCRIPTION
… with the audit ReplayClient.

I'm sure I screwed up by updating the pom from snapshot to release.  I can fix that and we can do a separate release commit if need be.  I just wanted eyes on this since there are multiple PRs associated with this both here and in datawave-spring-boot-starter-audit.

https://github.com/NationalSecurityAgency/datawave-spring-boot-starter-audit/pull/1